### PR TITLE
Add calendar-based monthly to-do list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Monthly To-Do Calendar</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 20px;
+        }
+        h1 {
+            text-align: center;
+        }
+        .calendar {
+            display: grid;
+            grid-template-columns: repeat(7, 1fr);
+            gap: 10px;
+            max-width: 900px;
+            margin: 20px auto;
+        }
+        .day {
+            background: white;
+            border-radius: 8px;
+            padding: 10px;
+            min-height: 120px;
+            box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+            display: flex;
+            flex-direction: column;
+        }
+        .day-number {
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+        .tasks {
+            flex-grow: 1;
+            padding-left: 20px;
+            margin: 0;
+        }
+        .tasks li {
+            list-style: none;
+        }
+        .add-task {
+            margin-top: 5px;
+        }
+    </style>
+</head>
+<body>
+    <h1 id="monthYear"></h1>
+    <div id="calendar" class="calendar"></div>
+    <script>
+        const calendar = document.getElementById('calendar');
+        const monthYear = document.getElementById('monthYear');
+        const date = new Date();
+        const year = date.getFullYear();
+        const month = date.getMonth();
+        const monthNames = [
+            'January', 'February', 'March', 'April', 'May', 'June',
+            'July', 'August', 'September', 'October', 'November', 'December'
+        ];
+        monthYear.textContent = `${monthNames[month]} ${year}`;
+
+        const firstDay = new Date(year, month, 1).getDay();
+        const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+        for (let i = 0; i < firstDay; i++) {
+            const blank = document.createElement('div');
+            calendar.appendChild(blank);
+        }
+
+        for (let day = 1; day <= daysInMonth; day++) {
+            const dayDiv = document.createElement('div');
+            dayDiv.className = 'day';
+
+            const number = document.createElement('div');
+            number.className = 'day-number';
+            number.textContent = day;
+            dayDiv.appendChild(number);
+
+            const list = document.createElement('ul');
+            list.className = 'tasks';
+            dayDiv.appendChild(list);
+
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.placeholder = 'Add task...';
+            input.className = 'add-task';
+            input.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' && input.value.trim() !== '') {
+                    const li = document.createElement('li');
+                    li.textContent = input.value;
+                    list.appendChild(li);
+                    input.value = '';
+                }
+            });
+            dayDiv.appendChild(input);
+
+            calendar.appendChild(dayDiv);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create an interactive monthly to-do list calendar with per-day task entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d2a0e19c832ebfb130e58be72499